### PR TITLE
update filter struct to be all arrays

### DIFF
--- a/examples/dm.rs
+++ b/examples/dm.rs
@@ -30,14 +30,14 @@ fn main() -> Result<(), Box<dyn Error>> {
         "abcdefg",
         vec![SubscriptionFilter::new()
             .authors(vec![alice_keys.public_key])
-            .tag_p(bob_keys.public_key)],
+            .pubkey(bob_keys.public_key)],
     );
 
     let subscribe_to_bob = ClientMessage::new_req(
         "123456",
         vec![SubscriptionFilter::new()
             .authors(vec![bob_keys.public_key])
-            .tag_p(alice_keys.public_key)],
+            .pubkey(alice_keys.public_key)],
     );
 
     println!("Subscribing to Alice");


### PR DESCRIPTION
nip01's filter section was updated (https://github.com/fiatjaf/nostr/blob/master/nips/01.md#from-client-to-relay-sending-events-and-creating-subscriptions), this is trying to keep pace

tests work and the dm / tweet examples kind of work but not great. need better examples for better testing!